### PR TITLE
Add package for grants a single pause for a prespecified duration.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -204,10 +204,12 @@ dependencies = [
  "cw-pause-once",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
- "cw2",
+ "cw2 0.15.1",
  "cw721",
  "cw721-base",
  "cw721-proxy-derive",
+ "cw721-rate-limited-proxy",
+ "cwd-interface",
  "serde",
  "thiserror",
 ]
@@ -221,7 +223,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-ics721-bridge",
  "cw-storage-plus 0.15.1",
- "cw2",
+ "cw2 0.15.1",
  "thiserror",
 ]
 
@@ -247,7 +249,7 @@ dependencies = [
 [[package]]
 name = "cw-paginate"
 version = "0.2.0"
-source = "git+https://github.com/DA0-DA0/dao-contracts.git#1a2accbb425ba928845fa0a0f4231cb1fe9824a6"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v2.0.0-beta#2ff37311f4335b6c5b2e49f8d3727313a86a251f"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -263,6 +265,19 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-rate-limiter"
+version = "0.0.1"
+source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "schemars",
+ "serde",
  "thiserror",
 ]
 
@@ -308,11 +323,23 @@ checksum = "0ae0b69fa7679de78825b4edeeec045066aa2b2c4b6e063d80042e565bb4da5c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2",
+ "cw2 0.15.1",
  "schemars",
  "semver",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "cw2"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.13.4",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -351,7 +378,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
- "cw2",
+ "cw2 0.15.1",
  "cw721",
  "schemars",
  "serde",
@@ -359,14 +386,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw721-proxy"
+version = "0.0.1"
+source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw721",
+ "cw721-proxy-derive",
+ "thiserror",
+]
+
+[[package]]
 name = "cw721-proxy-derive"
 version = "0.0.1"
-source = "git+https://github.com/ezekiiel/cw721-proxy.git#463908f507264892f3661bbdf84a6b46121c9342"
+source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
 dependencies = [
  "cw721",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cw721-rate-limited-proxy"
+version = "0.0.1"
+source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-rate-limiter",
+ "cw-storage-plus 0.15.1",
+ "cw2 0.15.1",
+ "cw721",
+ "cw721-proxy",
+ "cw721-proxy-derive",
+ "thiserror",
 ]
 
 [[package]]
@@ -376,9 +432,31 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw2",
+ "cw2 0.15.1",
  "cw721-base",
  "thiserror",
+]
+
+[[package]]
+name = "cwd-interface"
+version = "0.2.0"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v2.0.0-beta#2ff37311f4335b6c5b2e49f8d3727313a86a251f"
+dependencies = [
+ "cosmwasm-std",
+ "cw2 0.13.4",
+ "cwd-macros",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cwd-macros"
+version = "0.2.0"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v2.0.0-beta#2ff37311f4335b6c5b2e49f8d3727313a86a251f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -531,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -584,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "opaque-debug"
@@ -766,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -833,9 +911,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -882,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-paginate",
+ "cw-pause-once",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
  "cw2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,6 @@ version = "0.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-paginate",
  "cw-storage-plus 0.15.1",
@@ -247,12 +246,23 @@ dependencies = [
 [[package]]
 name = "cw-paginate"
 version = "0.2.0"
-source = "git+https://github.com/DA0-DA0/dao-contracts.git#eeae76ffea38994bcd07d708032b54c920a8b630"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git#1a2accbb425ba928845fa0a0f4231cb1fe9824a6"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus 0.13.4",
  "serde",
+]
+
+[[package]]
+name = "cw-pause-once"
+version = "0.0.1"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.15.1",
+ "cw-utils 0.15.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -350,7 +360,7 @@ dependencies = [
 [[package]]
 name = "cw721-proxy-derive"
 version = "0.0.1"
-source = "git+https://github.com/ezekiiel/cw721-proxy.git#f7c5a1d23ceeaa6d16dd9170adf0bbfc5eb186ac"
+source = "git+https://github.com/ezekiiel/cw721-proxy.git#463908f507264892f3661bbdf84a6b46121c9342"
 dependencies = [
  "cw721",
  "proc-macro2",
@@ -555,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "k256"
@@ -790,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/*"]
+members = ["contracts/*", "packages/*"]
 resolver = "2"
 
 [profile.release]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 ekez
+Copyright 2022 Public Awesome
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -14,7 +14,6 @@ library = []
 
 [dependencies]
 cosmwasm-std = { version = "1.1", features = ["stargate"] }
-cosmwasm-storage = "1.1"
 cosmwasm-schema = "1.1"
 cw-storage-plus = "0.15"
 cw-utils = "0.15"
@@ -27,5 +26,4 @@ cw721-proxy-derive = { git = "https://github.com/ezekiiel/cw721-proxy.git" }
 serde = "1.0"
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
 cw-multi-test = "0.13.4"

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -22,9 +22,11 @@ cw721 = "0.15"
 cw721-base = { version = "0.15", features = ["library"] }
 thiserror = "1"
 serde = "1.0"
-cw-paginate = { git = "https://github.com/DA0-DA0/dao-contracts.git" }
-cw721-proxy-derive = { git = "https://github.com/ezekiiel/cw721-proxy.git" }
+cw-paginate = { git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v2.0.0-beta" }
+cwd-interface = { git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v2.0.0-beta" }
+cw721-proxy-derive = { git = "https://github.com/0xekez/cw721-proxy.git" }
 cw-pause-once = { path = "../../packages/cw-pause-once" }
 
 [dev-dependencies]
 cw-multi-test = "0.13.4"
+cw721-rate-limited-proxy = { git = "https://github.com/0xekez/cw721-proxy.git" }

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -21,9 +21,10 @@ cw2 = "0.15"
 cw721 = "0.15"
 cw721-base = { version = "0.15", features = ["library"] }
 thiserror = "1"
+serde = "1.0"
 cw-paginate = { git = "https://github.com/DA0-DA0/dao-contracts.git" }
 cw721-proxy-derive = { git = "https://github.com/ezekiiel/cw721-proxy.git" }
-serde = "1.0"
+cw-pause-once = { path = "../../packages/cw-pause-once" }
 
 [dev-dependencies]
 cw-multi-test = "0.13.4"

--- a/contracts/cw-ics721-bridge/src/contract.rs
+++ b/contracts/cw-ics721-bridge/src/contract.rs
@@ -143,7 +143,7 @@ fn execute_receive_nft(
     msg: Binary,
 ) -> Result<Response, ContractError> {
     if PROXY.load(deps.storage)?.is_some() {
-        return Err(ContractError::Unauthorized {});
+        Err(ContractError::Unauthorized {})
     } else {
         do_receive_nft(deps, info, token_id, sender, msg)
     }

--- a/contracts/cw-ics721-bridge/src/error.rs
+++ b/contracts/cw-ics721-bridge/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::StdError;
+use cw_pause_once::PauseError;
 use cw_utils::ParseReplyError;
 use thiserror::Error;
 
@@ -6,6 +7,9 @@ use thiserror::Error;
 pub enum ContractError {
     #[error(transparent)]
     Std(#[from] StdError),
+
+    #[error(transparent)]
+    Pause(#[from] PauseError),
 
     #[error("unauthorized")]
     Unauthorized {},

--- a/contracts/cw-ics721-bridge/src/ibc_helpers.rs
+++ b/contracts/cw-ics721-bridge/src/ibc_helpers.rs
@@ -129,10 +129,10 @@ impl NonFungibleTokenPacketData {
             return Err(ContractError::TokenInfoLenMissmatch {});
         }
 
-        // TODO: Should we check the tokenIds field for duplicates?
-        // O(log(N)). A well behaved cw721 implementation will catch
-        // this downstream if we try and mint / trasnfer the same
-        // token twice.
+        // Could check the tokenIds field for duplicates, O(log(N)). A
+        // well behaved cw721 implementation will catch this
+        // downstream if we try and mint / trasnfer the same token
+        // twice.
 
         Ok(())
     }

--- a/contracts/cw-ics721-bridge/src/ibc_packet_receive.rs
+++ b/contracts/cw-ics721-bridge/src/ibc_packet_receive.rs
@@ -7,7 +7,7 @@ use crate::{
     ibc::{NonFungibleTokenPacketData, ACK_AND_DO_NOTHING},
     ibc_helpers::{get_endpoint_prefix, try_pop_source_prefix},
     msg::{CallbackMsg, ExecuteMsg, NewTokenInfo, TransferInfo},
-    state::{INCOMING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_CLASS_TOKEN_TO_CHANNEL},
+    state::{INCOMING_CLASS_TOKEN_TO_CHANNEL, OUTGOING_CLASS_TOKEN_TO_CHANNEL, PO},
     ContractError,
 };
 
@@ -39,6 +39,8 @@ pub(crate) fn do_ibc_packet_receive(
     env: Env,
     packet: IbcPacket,
 ) -> Result<IbcReceiveResponse, ContractError> {
+    PO.error_if_paused(deps.storage)?;
+
     let data: NonFungibleTokenPacketData = from_binary(&packet.data)?;
     data.validate()?;
 

--- a/contracts/cw-ics721-bridge/src/ibc_tests.rs
+++ b/contracts/cw-ics721-bridge/src/ibc_tests.rs
@@ -83,6 +83,7 @@ fn do_instantiate(deps: DepsMut, env: Env, sender: &str) -> Result<Response, Con
     let msg = InstantiateMsg {
         cw721_base_code_id: CW721_CODE_ID,
         proxy: None,
+        pauser: None,
     };
     instantiate(deps, env, mock_info(sender, &[]), msg)
 }

--- a/contracts/cw-ics721-bridge/src/integration_tests.rs
+++ b/contracts/cw-ics721-bridge/src/integration_tests.rs
@@ -37,6 +37,7 @@ fn instantiate_bridge(app: &mut App) -> Addr {
         &InstantiateMsg {
             cw721_base_code_id: cw721_id,
             proxy: None,
+            pauser: None,
         },
         &[],
         "cw-ics721-bridge",
@@ -55,6 +56,7 @@ fn instantiate_bridge_with_proxy(app: &mut App, proxy: Option<String>) -> Addr {
         &InstantiateMsg {
             cw721_base_code_id: cw721_id,
             proxy,
+            pauser: None,
         },
         &[],
         "cw-ics721-bridge",

--- a/contracts/cw-ics721-bridge/src/msg.rs
+++ b/contracts/cw-ics721-bridge/src/msg.rs
@@ -1,6 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::IbcTimeout;
 use cw721_proxy_derive::cw721_proxy;
+use cwd_interface::ModuleInstantiateInfo;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -16,7 +17,7 @@ pub struct InstantiateMsg {
     /// will only accept NFTs from that proxy. The proxy is expected
     /// to implement the cw721 proxy interface defined in the
     /// cw721-proxy crate.
-    pub proxy: Option<String>,
+    pub proxy: Option<ModuleInstantiateInfo>,
     /// Address that may pause the contract. PAUSER may pause the
     /// contract a single time; in pausing the contract they burn the
     /// right to do so again. A new pauser may be later nominated by

--- a/contracts/cw-ics721-bridge/src/msg.rs
+++ b/contracts/cw-ics721-bridge/src/msg.rs
@@ -1,7 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{to_binary, Addr, Env, IbcTimeout, StdResult, WasmMsg};
+use cosmwasm_std::IbcTimeout;
 use cw721_proxy_derive::cw721_proxy;
-use cw_pause_once::UncheckedPausePolicy;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -11,18 +10,18 @@ pub struct InstantiateMsg {
     /// NOTE: this _must_ correspond to the cw721-base contract. Using
     /// a regular cw721 may cause the ICS 721 interface implemented by
     /// this contract to stop working, and IBCd away NFTs to be
-    /// unreturnable (cw721 does not have a mint method in the spec).
+    /// unreturnable as cw721 does not have a mint method in the spec.
     pub cw721_base_code_id: u64,
     /// An optional proxy contract. If a proxy is set the contract
     /// will only accept NFTs from that proxy. The proxy is expected
     /// to implement the cw721 proxy interface defined in the
     /// cw721-proxy crate.
     pub proxy: Option<String>,
-    /// Policy for pausing this contract. If policy is none, the
-    /// contract will not be pausable. Otherwise, the contract will be
-    /// pausable a single time by a prespecified address for a
-    /// prespecified duration.
-    pub pause_policy: Option<UncheckedPausePolicy>,
+    /// Address that may pause the contract. PAUSER may pause the
+    /// contract a single time; in pausing the contract they burn the
+    /// right to do so again. A new pauser may be later nominated by
+    /// the CosmWasm level admin via a migration.
+    pub pauser: Option<String>,
 }
 
 #[cw721_proxy]
@@ -32,9 +31,8 @@ pub enum ExecuteMsg {
     /// be a binary encoded `IbcAwayMsg`.
     ReceiveNft(cw721::Cw721ReceiveMsg),
 
-    /// Pauses the bridge. Only an address allowed by the pause
-    /// policy may execute this method. The bridge will automatically
-    /// unpause after duration specified in the pause policy.
+    /// Pauses the bridge. Only the pauser may call this. In pausing
+    /// the contract, the pauser burns the right to do so again.
     Pause {},
 
     /// Mesages used internally by the contract. These may only be
@@ -94,23 +92,33 @@ pub enum CallbackMsg {
     /// and NEW_TOKENS into a `DoInstantiateAndMint`, then dispatches
     /// those methods.
     HandlePacketReceive {
+        /// The address receiving the NFTs.
         receiver: String,
+        /// The URI for the collection being transfered.
         class_uri: Option<String>,
+        /// Information about transfer actions.
         transfers: Option<TransferInfo>,
+        /// Information about mint actions.
         new_tokens: Option<NewTokenInfo>,
     },
 }
 
 #[cw_serde]
 pub struct TransferInfo {
+    /// The class ID the tokens belong to.
     pub class_id: String,
+    /// The tokens to be transfered.
     pub token_ids: Vec<String>,
 }
 
 #[cw_serde]
 pub struct NewTokenInfo {
+    /// The class ID to mint tokens for.
     pub class_id: String,
+    /// The token IDs of the tokens to be minted.
     pub token_ids: Vec<String>,
+    /// The URIs of the tokens to be minted. Matched with token_ids by
+    /// index.
     pub token_uris: Vec<String>,
 }
 
@@ -139,7 +147,7 @@ pub enum QueryMsg {
     /// Gets the NFT contract associated wtih the provided class
     /// ID. If no such contract exists, returns None. Returns
     /// Option<Addr>.
-    #[returns(Option<Addr>)]
+    #[returns(Option<::cosmwasm_std::Addr>)]
     NftContractForClassId { class_id: String },
 
     /// Gets the class level metadata URI for the provided
@@ -151,49 +159,30 @@ pub enum QueryMsg {
     /// Gets the owner of the NFT identified by CLASS_ID and
     /// TOKEN_ID. Errors if no such NFT exists. Returns
     /// `cw721::OwnerOfResonse`.
-    #[returns(cw721::OwnerOfResponse)]
+    #[returns(::cw721::OwnerOfResponse)]
     Owner { class_id: String, token_id: String },
+
+    /// Gets the address that may pause this contract if one is set.
+    #[returns(Option<::cosmwasm_std::Addr>)]
+    Pauser {},
+
+    /// Gets the current pause status.
+    #[returns(bool)]
+    Paused {},
+
+    /// Gets this contract's cw721-proxy if one is set.
+    #[returns(Option<::cosmwasm_std::Addr>)]
+    Proxy {},
 }
 
 #[cw_serde]
 pub enum MigrateMsg {
     WithUpdate {
-        pause_policy: Option<UncheckedPausePolicy>,
+        /// The address that may pause the contract. If `None` is
+        /// provided the current pauser will be removed.
+        pauser: Option<String>,
+        /// The cw721-proxy for this contract. If `None` is provided
+        /// the current proxy will be removed.
         proxy: Option<String>,
     },
-}
-
-impl TransferInfo {
-    pub(crate) fn into_wasm_msg(self, env: &Env, receiver: &Addr) -> StdResult<WasmMsg> {
-        Ok(WasmMsg::Execute {
-            contract_addr: env.contract.address.to_string(),
-            msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::BatchTransfer {
-                class_id: self.class_id,
-                receiver: receiver.to_string(),
-                token_ids: self.token_ids,
-            }))?,
-            funds: vec![],
-        })
-    }
-}
-
-impl NewTokenInfo {
-    pub(crate) fn into_wasm_msg(
-        self,
-        env: &Env,
-        receiver: &Addr,
-        class_uri: Option<String>,
-    ) -> StdResult<WasmMsg> {
-        Ok(WasmMsg::Execute {
-            contract_addr: env.contract.address.to_string(),
-            msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::DoInstantiateAndMint {
-                class_id: self.class_id,
-                class_uri,
-                receiver: receiver.to_string(),
-                token_ids: self.token_ids,
-                token_uris: self.token_uris,
-            }))?,
-            funds: vec![],
-        })
-    }
 }

--- a/contracts/cw-ics721-bridge/src/state.rs
+++ b/contracts/cw-ics721-bridge/src/state.rs
@@ -1,11 +1,14 @@
 use cosmwasm_std::{Addr, Empty};
+use cw_pause_once::PauseOrchestrator;
 use cw_storage_plus::{Item, Map};
 use serde::Deserialize;
 
 /// The code ID we will use for instantiating new cw721s.
-pub const CW721_ICS_CODE_ID: Item<u64> = Item::new("cw721_code_id");
+pub const CW721_CODE_ID: Item<u64> = Item::new("cw721_code_id");
 /// The proxy that this contract is receiving NFTs from, if any.
 pub const PROXY: Item<Option<Addr>> = Item::new("proxy");
+/// Manages contract pauses.
+pub const PO: PauseOrchestrator = PauseOrchestrator::new("policy", "paused");
 
 /// Maps classID (from NonFungibleTokenPacketData) to the cw721
 /// contract we have instantiated for that classID.

--- a/e2e/adversarial_test.go
+++ b/e2e/adversarial_test.go
@@ -75,6 +75,8 @@ func (suite *AdversarialTestSuite) SetupTest() {
 
 		instantiateBridge := InstantiateICS721Bridge{
 			2,
+			nil,
+			nil,
 		}
 		instantiateBridgeRaw, err := json.Marshal(instantiateBridge)
 		require.NoError(suite.T(), err)

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -48,10 +48,11 @@ func (suite *TransferTestSuite) SetupTest() {
 	chainBStoreResp = suite.chainB.StoreCodeFile("../external-wasms/cw721_base_v0.15.0.wasm")
 	require.Equal(suite.T(), uint64(2), chainBStoreResp.CodeID)
 
-	// Store the cw721_base contract.
-
 	instantiateICS721 := InstantiateICS721Bridge{
 		2,
+		// no pauser nor proxy by default.
+		nil,
+		nil,
 	}
 	instantiateICS721Raw, err := json.Marshal(instantiateICS721)
 	require.NoError(suite.T(), err)
@@ -265,6 +266,8 @@ func instantiateBridge(t *testing.T, chain *wasmibctesting.TestChain) sdk.AccAdd
 	// Instantiate the bridge contract.
 	instantiateICS721 := InstantiateICS721Bridge{
 		cw721resp.CodeID,
+		nil,
+		nil,
 	}
 	instantiateICS721Raw, err := json.Marshal(instantiateICS721)
 	require.NoError(t, err)
@@ -591,6 +594,8 @@ func TestCloseRejected(t *testing.T) {
 	// Store the cw721_base contract.
 	instantiateICS721 := InstantiateICS721Bridge{
 		2,
+		nil,
+		nil,
 	}
 	instantiateICS721Raw, err := json.Marshal(instantiateICS721)
 	require.NoError(t, err)
@@ -767,19 +772,4 @@ func (suite *TransferTestSuite) TestRefundOnAckFail() {
 	// Check that the NFT was returned to the sender due to the failure.
 	ownerA := queryGetOwnerOf(suite.T(), suite.chainA, chainANft.String())
 	require.Equal(suite.T(), suite.chainA.SenderAccount.GetAddress().String(), ownerA)
-}
-
-// Tests that each contract query retuns the expected data both for
-// known, and unknown class IDs and NFT addresses.
-func (suite *TransferTestSuite) TestQueries() {
-}
-
-// Tests that the contract rejects connections that use an incorrect
-// IBC version.
-func TestConnectionFailsWithWrongVersion(t *testing.T) {
-}
-
-// Tests that the contract rejects connections that use an incorrect
-// ordering.
-func TestConnectionFailsWithWrongOrdering(t *testing.T) {
 }

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -1,7 +1,16 @@
 package e2e_test
 
+type ModuleInstantiateInfo struct {
+	CodeID uint64 `json:"code_id"`
+	Msg    string `json:"msg"`
+	Admin  string `json:"admin"`
+	Label  string `json:"label"`
+}
+
 type InstantiateICS721Bridge struct {
-	CW721CodeID uint64 `json:"cw721_base_code_id"`
+	CW721CodeID uint64                 `json:"cw721_base_code_id"`
+	Proxy       *ModuleInstantiateInfo `json:"proxy"`
+	Pauser      *string                `json:"pauser"`
 }
 
 type InstantiateCw721 struct {

--- a/packages/cw-pause-once/Cargo.toml
+++ b/packages/cw-pause-once/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cw-pause-once"
+version = "0.0.1"
+edition = "2021"
+authors = ["ekez <ekez@withoutdoing.com>"]
+description = "a package to allow an address to pause a single time for a prespecified duration"
+
+[dependencies]
+cosmwasm-std = "1.1"
+cosmwasm-schema = "1.1"
+cw-utils = "0.15"
+cw-storage-plus = "0.15"
+thiserror = "1"

--- a/packages/cw-pause-once/README
+++ b/packages/cw-pause-once/README
@@ -1,0 +1,11 @@
+This provides a simple type, `PauseOrchestrator`, that allows a
+specified address to execute a pause a single time and pause for a
+prespecified duration.
+
+This might be useful if you want to delegate the ability to pause
+a contract to an address, while also not allowing that address to
+perminantly lock the contract. For example, you may want to set
+the prespecified duration to slightly over one governance cycle
+for SDK governance, and then set a small subDAO as the
+pauser. This way the subDAO may pause the contract quickly, but
+must be reauthorized by governance to do it again.

--- a/packages/cw-pause-once/src/lib.rs
+++ b/packages/cw-pause-once/src/lib.rs
@@ -1,0 +1,152 @@
+//! This provides a simple type, `PauseOrchestrator`, that allows a
+//! specified address to execute a pause a single time and pause for a
+//! prespecified duration.
+//!
+//! This might be useful if you want to delegate the ability to pause
+//! a contract to an address, while also not allowing that address to
+//! perminantly lock the contract. For example, you may want to set
+//! the prespecified duration to slightly over one governance cycle
+//! for SDK governance, and then set a small subDAO as the
+//! pauser. This way the subDAO may pause the contract quickly, but
+//! must be reauthorized by governance to do it again.
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Api, BlockInfo, StdError, StdResult, Storage};
+use cw_storage_plus::Item;
+use cw_utils::{Duration, Expiration};
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum PauseError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+
+    #[error("paused. unpause scheduled for ({expiration})")]
+    Paused { expiration: Expiration },
+
+    #[error("unauthorized pauser ({sender})")]
+    Unauthorized { sender: Addr },
+}
+
+#[cw_serde]
+pub struct UncheckedPausePolicy {
+    pauser: String,
+    pause_duration: Duration,
+}
+
+#[cw_serde]
+pub struct PausePolicy {
+    pauser: Addr,
+    pause_duration: Duration,
+}
+
+pub struct PauseOrchestrator<'a> {
+    policy: Item<'a, Option<PausePolicy>>,
+    paused_until: Item<'a, Option<Expiration>>,
+}
+
+impl UncheckedPausePolicy {
+    pub fn into_checked(self, api: &dyn Api) -> StdResult<PausePolicy> {
+        Ok(PausePolicy {
+            pauser: api.addr_validate(&self.pauser)?,
+            pause_duration: self.pause_duration,
+        })
+    }
+}
+
+impl<'a> PauseOrchestrator<'a> {
+    /// Creates a new pause orchestrator using the provided storage
+    /// keys.
+    pub const fn new(policy_key: &'a str, paused_key: &'a str) -> Self {
+        Self {
+            policy: Item::new(policy_key),
+            paused_until: Item::new(paused_key),
+        }
+    }
+
+    /// Sets a new pause policy and resets any old pauses that may be
+    /// present. This must be called at least once per instance of
+    /// `PauseOrchestrator`.
+    pub fn set_policy(
+        &self,
+        storage: &mut dyn Storage,
+        policy: Option<PausePolicy>,
+    ) -> StdResult<()> {
+        self.policy.save(storage, &policy)?;
+        self.paused_until.save(storage, &None)
+    }
+
+    /// Errors if the module is paused, does nothing otherwise.
+    pub fn error_if_paused(
+        &self,
+        storage: &dyn Storage,
+        block: &BlockInfo,
+    ) -> Result<(), PauseError> {
+        self.paused_until
+            .load(storage)?
+            .map_or(Ok(()), |expiration| {
+                if !expiration.is_expired(block) {
+                    Err(PauseError::Paused { expiration })
+                } else {
+                    Ok(())
+                }
+            })
+    }
+
+    /// Pauses the module and removes the previous pauser's ability to
+    /// pause.
+    pub fn pause(
+        &self,
+        storage: &mut dyn Storage,
+        sender: &Addr,
+        block: &BlockInfo,
+    ) -> Result<(), PauseError> {
+        self.error_if_paused(storage, block)?;
+
+        let policy = self.policy.load(storage)?;
+        if let Some(PausePolicy {
+            pauser,
+            pause_duration,
+        }) = policy
+        {
+            if pauser == *sender {
+                self.policy.save(storage, &None)?;
+                self.paused_until
+                    .save(storage, &Some(pause_duration.after(block)))?;
+                return Ok(());
+            }
+        }
+        Err(PauseError::Unauthorized {
+            sender: sender.clone(),
+        })
+    }
+
+    /// Gets the pause policy for this orchestrator. If there is no
+    /// pause policy (the orchestrator may not be paused), returns
+    /// None.
+    pub fn query_pause_policy(&self, storage: &mut dyn Storage) -> StdResult<Option<PausePolicy>> {
+        self.policy.load(storage)
+    }
+
+    /// Gets when this orchestrator will unpause. If the orchestrator
+    /// is not paused, returns None.
+    pub fn query_paused_until(
+        &self,
+        storage: &mut dyn Storage,
+        block: &BlockInfo,
+    ) -> StdResult<Option<Expiration>> {
+        let paused_until = self.paused_until.load(storage)?;
+        Ok(paused_until
+            .map(|paused_until| {
+                if paused_until.is_expired(block) {
+                    None
+                } else {
+                    Some(paused_until)
+                }
+            })
+            .flatten())
+    }
+}

--- a/packages/cw-pause-once/src/lib.rs
+++ b/packages/cw-pause-once/src/lib.rs
@@ -1,19 +1,8 @@
 //! This provides a simple type, `PauseOrchestrator`, that allows a
-//! specified address to execute a pause a single time and pause for a
-//! prespecified duration.
-//!
-//! This might be useful if you want to delegate the ability to pause
-//! a contract to an address, while also not allowing that address to
-//! perminantly lock the contract. For example, you may want to set
-//! the prespecified duration to slightly over one governance cycle
-//! for SDK governance, and then set a small subDAO as the
-//! pauser. This way the subDAO may pause the contract quickly, but
-//! must be reauthorized by governance to do it again.
+//! specified address to execute a pause a single time.
 
-use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Api, BlockInfo, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, Api, StdError, StdResult, Storage};
 use cw_storage_plus::Item;
-use cw_utils::{Duration, Expiration};
 use thiserror::Error;
 
 #[cfg(test)]
@@ -24,129 +13,76 @@ pub enum PauseError {
     #[error(transparent)]
     Std(#[from] StdError),
 
-    #[error("paused. unpause scheduled for ({expiration})")]
-    Paused { expiration: Expiration },
+    #[error("contract is paused pending governance intervention")]
+    Paused {},
 
     #[error("unauthorized pauser ({sender})")]
     Unauthorized { sender: Addr },
 }
 
-#[cw_serde]
-pub struct UncheckedPausePolicy {
-    pauser: String,
-    pause_duration: Duration,
-}
-
-#[cw_serde]
-pub struct PausePolicy {
-    pauser: Addr,
-    pause_duration: Duration,
-}
-
 pub struct PauseOrchestrator<'a> {
-    policy: Item<'a, Option<PausePolicy>>,
-    paused_until: Item<'a, Option<Expiration>>,
-}
-
-impl UncheckedPausePolicy {
-    pub fn into_checked(self, api: &dyn Api) -> StdResult<PausePolicy> {
-        Ok(PausePolicy {
-            pauser: api.addr_validate(&self.pauser)?,
-            pause_duration: self.pause_duration,
-        })
-    }
+    pauser: Item<'a, Option<Addr>>,
+    paused: Item<'a, bool>,
 }
 
 impl<'a> PauseOrchestrator<'a> {
     /// Creates a new pause orchestrator using the provided storage
     /// keys.
-    pub const fn new(policy_key: &'a str, paused_key: &'a str) -> Self {
+    pub const fn new(pauser_key: &'a str, paused_key: &'a str) -> Self {
         Self {
-            policy: Item::new(policy_key),
-            paused_until: Item::new(paused_key),
+            pauser: Item::new(pauser_key),
+            paused: Item::new(paused_key),
         }
     }
 
-    /// Sets a new pause policy and resets any old pauses that may be
-    /// present. This must be called at least once per instance of
-    /// `PauseOrchestrator`.
-    pub fn set_policy(
+    /// Sets a new pauser who may pause the contract. If the contract
+    /// is paused, it is unpaused.
+    pub fn set_pauser(
         &self,
         storage: &mut dyn Storage,
-        policy: Option<PausePolicy>,
+        api: &dyn Api,
+        pauser: Option<&str>,
     ) -> StdResult<()> {
-        self.policy.save(storage, &policy)?;
-        self.paused_until.save(storage, &None)
+        self.pauser
+            .save(storage, &pauser.map(|h| api.addr_validate(h)).transpose()?)?;
+        self.paused.save(storage, &false)
     }
 
     /// Errors if the module is paused, does nothing otherwise.
-    pub fn error_if_paused(
-        &self,
-        storage: &dyn Storage,
-        block: &BlockInfo,
-    ) -> Result<(), PauseError> {
-        self.paused_until
-            .load(storage)?
-            .map_or(Ok(()), |expiration| {
-                if !expiration.is_expired(block) {
-                    Err(PauseError::Paused { expiration })
-                } else {
-                    Ok(())
-                }
-            })
+    pub fn error_if_paused(&self, storage: &dyn Storage) -> Result<(), PauseError> {
+        if self.paused.load(storage)? {
+            Err(PauseError::Paused {})
+        } else {
+            Ok(())
+        }
     }
 
     /// Pauses the module and removes the previous pauser's ability to
     /// pause.
-    pub fn pause(
-        &self,
-        storage: &mut dyn Storage,
-        sender: &Addr,
-        block: &BlockInfo,
-    ) -> Result<(), PauseError> {
-        self.error_if_paused(storage, block)?;
+    pub fn pause(&self, storage: &mut dyn Storage, sender: &Addr) -> Result<(), PauseError> {
+        self.error_if_paused(storage)?;
 
-        let policy = self.policy.load(storage)?;
-        if let Some(PausePolicy {
-            pauser,
-            pause_duration,
-        }) = policy
-        {
-            if pauser == *sender {
-                self.policy.save(storage, &None)?;
-                self.paused_until
-                    .save(storage, &Some(pause_duration.after(block)))?;
-                return Ok(());
-            }
+        let pauser = self.pauser.load(storage)?;
+        if pauser.as_ref().map_or(true, |pauser| sender != pauser) {
+            Err(PauseError::Unauthorized {
+                sender: sender.clone(),
+            })
+        } else {
+            self.paused.save(storage, &true)?;
+            Ok(())
         }
-        Err(PauseError::Unauthorized {
-            sender: sender.clone(),
-        })
     }
 
     /// Gets the pause policy for this orchestrator. If there is no
     /// pause policy (the orchestrator may not be paused), returns
     /// None.
-    pub fn query_pause_policy(&self, storage: &mut dyn Storage) -> StdResult<Option<PausePolicy>> {
-        self.policy.load(storage)
+    pub fn query_pauser(&self, storage: &dyn Storage) -> StdResult<Option<Addr>> {
+        self.pauser.load(storage)
     }
 
     /// Gets when this orchestrator will unpause. If the orchestrator
     /// is not paused, returns None.
-    pub fn query_paused_until(
-        &self,
-        storage: &mut dyn Storage,
-        block: &BlockInfo,
-    ) -> StdResult<Option<Expiration>> {
-        let paused_until = self.paused_until.load(storage)?;
-        Ok(paused_until
-            .map(|paused_until| {
-                if paused_until.is_expired(block) {
-                    None
-                } else {
-                    Some(paused_until)
-                }
-            })
-            .flatten())
+    pub fn query_paused(&self, storage: &dyn Storage) -> StdResult<bool> {
+        self.paused.load(storage)
     }
 }

--- a/packages/cw-pause-once/src/lib.rs
+++ b/packages/cw-pause-once/src/lib.rs
@@ -68,6 +68,7 @@ impl<'a> PauseOrchestrator<'a> {
                 sender: sender.clone(),
             })
         } else {
+            self.pauser.save(storage, &None)?;
             self.paused.save(storage, &true)?;
             Ok(())
         }

--- a/packages/cw-pause-once/src/tests.rs
+++ b/packages/cw-pause-once/src/tests.rs
@@ -1,0 +1,103 @@
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env},
+    Addr,
+};
+use cw_utils::{Duration, Expiration};
+
+use crate::{PauseError, PauseOrchestrator, UncheckedPausePolicy};
+
+#[test]
+fn test_pause() {
+    let mut deps = mock_dependencies();
+    let mut env = mock_env();
+
+    let policy = UncheckedPausePolicy {
+        pauser: "ekez".to_string(),
+        pause_duration: Duration::Height(1),
+    };
+
+    let po = PauseOrchestrator::new("policy", "pause");
+    po.set_policy(
+        &mut deps.storage,
+        Some(policy.into_checked(&deps.api).unwrap()),
+    )
+    .unwrap();
+
+    // Only the designated pauser may pause.
+    let err: PauseError = po
+        .pause(&mut deps.storage, &Addr::unchecked("notekez"), &env.block)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        PauseError::Unauthorized {
+            sender: Addr::unchecked("notekez")
+        }
+    );
+    // Not paused.
+    po.error_if_paused(&deps.storage, &env.block).unwrap();
+
+    po.pause(&mut deps.storage, &Addr::unchecked("ekez"), &env.block)
+        .unwrap();
+
+    let err: PauseError = po.error_if_paused(&deps.storage, &env.block).unwrap_err();
+    assert_eq!(
+        err,
+        PauseError::Paused {
+            expiration: Expiration::AtHeight(env.block.height + 1)
+        }
+    );
+
+    // Time's arrow merely marches forward.
+    env.block.height += 1;
+
+    // No longer paused.
+    po.error_if_paused(&deps.storage, &env.block).unwrap();
+    // Original pauser burned their pause privledges.
+    let err: PauseError = po
+        .pause(&mut deps.storage, &Addr::unchecked("ekez"), &env.block)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        PauseError::Unauthorized {
+            sender: Addr::unchecked("ekez")
+        }
+    );
+
+    // Assign a new pauser.
+    let policy = UncheckedPausePolicy {
+        pauser: "meow".to_string(),
+        pause_duration: Duration::Time(100),
+    };
+    po.set_policy(
+        &mut deps.storage,
+        Some(policy.into_checked(&deps.api).unwrap()),
+    )
+    .unwrap();
+
+    // New pauser can pause.
+    po.pause(&mut deps.storage, &Addr::unchecked("meow"), &env.block)
+        .unwrap();
+
+    let err: PauseError = po.error_if_paused(&deps.storage, &env.block).unwrap_err();
+    assert_eq!(
+        err,
+        PauseError::Paused {
+            expiration: Expiration::AtTime(env.block.time.plus_seconds(100))
+        }
+    );
+
+    // Removing the pauser removes their pause as well.
+    po.set_policy(&mut deps.storage, None).unwrap();
+    po.error_if_paused(&deps.storage, &env.block).unwrap();
+
+    // With no policy set, attempting to pause fails.
+    let err: PauseError = po
+        .pause(&mut deps.storage, &Addr::unchecked("meow"), &env.block)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        PauseError::Unauthorized {
+            sender: Addr::unchecked("meow")
+        }
+    );
+}

--- a/ts-relayer-tests/src/ics721.spec.ts
+++ b/ts-relayer-tests/src/ics721.spec.ts
@@ -122,7 +122,7 @@ const standardSetup = async (t: ExecutionContext<TestContext>) => {
 };
 
 test.serial("transfer NFT", async (t) => {
-  standardSetup(t);
+  await standardSetup(t);
 
   const {
     wasmClient,
@@ -135,6 +135,7 @@ test.serial("transfer NFT", async (t) => {
     channel,
   } = t.context;
 
+  t.log(JSON.stringify(wasmClient, undefined, 2));
   const tokenId = "1";
   await mint(wasmClient, wasmCw721, tokenId, wasmAddr, undefined);
   // assert token is minted
@@ -186,7 +187,7 @@ test.serial("transfer NFT", async (t) => {
 });
 
 test.serial("malicious NFT", async (t) => {
-  standardSetup(t);
+  await standardSetup(t);
 
   const {
     wasmClient,

--- a/ts-relayer-tests/src/ics721.spec.ts
+++ b/ts-relayer-tests/src/ics721.spec.ts
@@ -1,5 +1,5 @@
 import { CosmWasmSigner } from "@confio/relayer";
-import anyTest, { TestFn } from "ava";
+import anyTest, { ExecutionContext, TestFn } from "ava";
 import { Order } from "cosmjs-types/ibc/core/channel/v1/channel";
 
 import { instantiateContract } from "./controller";
@@ -36,9 +36,10 @@ const test = anyTest as TestFn<TestContext>;
 
 const WASM_FILE_CW721 = "./internal/cw721_base_v0.15.0.wasm";
 const WASM_FILE_CW_ICS721_BRIDGE = "./internal/cw_ics721_bridge.wasm";
-const MALICIOUS_CW721 = "./internal/cw721_gas_tester.wasm";
+const MALICIOUS_CW721 = "./internal/cw721_tester.wasm";
+const BRIDGE_TESTER = "./internal/cw-ics721-bridge-tester";
 
-test.beforeEach(async (t) => {
+const standardSetup = async (t: ExecutionContext<TestContext>) => {
   t.context.wasmClient = await setupWasmClient(MNEMONIC);
   t.context.osmoClient = await setupOsmosisClient(MNEMONIC);
 
@@ -119,9 +120,11 @@ test.beforeEach(async (t) => {
   t.context.channel = channelInfo;
 
   t.pass();
-});
+};
 
 test.serial("transfer NFT", async (t) => {
+  standardSetup(t);
+
   const {
     wasmClient,
     wasmAddr,
@@ -184,6 +187,8 @@ test.serial("transfer NFT", async (t) => {
 });
 
 test.serial("malicious NFT", async (t) => {
+  standardSetup(t);
+
   const {
     wasmClient,
     osmoClient,

--- a/ts-relayer-tests/src/ics721.spec.ts
+++ b/ts-relayer-tests/src/ics721.spec.ts
@@ -37,7 +37,6 @@ const test = anyTest as TestFn<TestContext>;
 const WASM_FILE_CW721 = "./internal/cw721_base_v0.15.0.wasm";
 const WASM_FILE_CW_ICS721_BRIDGE = "./internal/cw_ics721_bridge.wasm";
 const MALICIOUS_CW721 = "./internal/cw721_tester.wasm";
-const BRIDGE_TESTER = "./internal/cw-ics721-bridge-tester";
 
 const standardSetup = async (t: ExecutionContext<TestContext>) => {
   t.context.wasmClient = await setupWasmClient(MNEMONIC);
@@ -207,7 +206,7 @@ test.serial("malicious NFT", async (t) => {
         name: "evil",
         symbol: "evil",
         minter: wasmClient.senderAddress,
-        target: wasmBridge, // run out of gas every time the bridge tries to return a NFT.
+        target: wasmBridge, // panic every time the bridge tries to return a NFT.
       },
     },
   });


### PR DESCRIPTION
This adds a package `cw-pause-once` described as follows:

> This provides a simple type, `PauseOrchestrator`, that allows a specified address to execute a pause a single time and pause for a prespecified duration.

> This might be useful if you want to delegate the ability to pause a contract to an address, while also not allowing that address to permanently lock the contract. For example, you may want to set the prespecified duration to slightly over one governance cycle for SDK governance, and then set a small subDAO as the pauser. This way the subDAO may pause the contract quickly, but must be reauthorized by governance to do it again.

See `test_pause` in `packages/cw-pause-once/src/tests.rs` for an example of this package's usage.