### PR TITLE
Add ibc3 feature

### DIFF
--- a/contracts/cw-ics721-bridge-tester/Cargo.toml
+++ b/contracts/cw-ics721-bridge-tester/Cargo.toml
@@ -13,7 +13,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.1", features = ["stargate"] }
+cosmwasm-std = { version = "1.1", features = ["stargate", "ibc3"] }
 cosmwasm-storage = "1.1"
 cosmwasm-schema = "1.1"
 cw-storage-plus = "0.15"

--- a/contracts/cw-ics721-bridge-tester/src/ibc.rs
+++ b/contracts/cw-ics721-bridge-tester/src/ibc.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     DepsMut, Env, IbcBasicResponse, IbcChannel, IbcChannelCloseMsg, IbcChannelConnectMsg,
     IbcChannelOpenMsg, IbcOrder, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg,
-    IbcReceiveResponse,
+    IbcReceiveResponse, Ibc3ChannelOpenResponse,
 };
 
 use crate::{
@@ -21,8 +21,9 @@ pub fn ibc_channel_open(
     _deps: DepsMut,
     _env: Env,
     msg: IbcChannelOpenMsg,
-) -> Result<(), ContractError> {
-    validate_order_and_version(msg.channel(), msg.counterparty_version())
+) -> Result<Option<Ibc3ChannelOpenResponse>, ContractError> {
+    validate_order_and_version(msg.channel(), msg.counterparty_version())?;
+    Ok(None)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/cw-ics721-bridge-tester/src/msg.rs
+++ b/contracts/cw-ics721-bridge-tester/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_schema::cw_serde;
+use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::IbcTimeout;
 
 #[cw_serde]
@@ -31,10 +31,13 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
+#[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Gets the current ack mode. Returns `AckMode`.
+    #[returns(AckMode)]
     AckMode {},
     /// Gets the mode of the last ack this contract received. Errors
     /// if no ACK has ever been received. Returns `AckMode`.
+    #[returns(AckMode)]
     LastAck {},
 }

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -13,7 +13,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.1", features = ["stargate"] }
+cosmwasm-std = { version = "1.1", features = ["stargate", "ibc3"] }
 cosmwasm-schema = "1.1"
 cw-storage-plus = "0.15"
 cw-utils = "0.15"

--- a/contracts/cw-ics721-bridge/src/ibc.rs
+++ b/contracts/cw-ics721-bridge/src/ibc.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     from_binary, to_binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacket, IbcPacketAckMsg, IbcPacketReceiveMsg,
-    IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdResult, SubMsgResult, WasmMsg,
+    IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdResult, SubMsgResult, WasmMsg, Ibc3ChannelOpenResponse,
 };
 use cw_utils::parse_reply_instantiate_data;
 
@@ -58,8 +58,9 @@ pub fn ibc_channel_open(
     _deps: DepsMut,
     _env: Env,
     msg: IbcChannelOpenMsg,
-) -> Result<(), ContractError> {
-    validate_order_and_version(msg.channel(), msg.counterparty_version())
+) -> Result<Option<Ibc3ChannelOpenResponse>, ContractError> {
+    validate_order_and_version(msg.channel(), msg.counterparty_version())?;
+    Ok(None)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/cw-ics721-bridge/src/ibc_tests.rs
+++ b/contracts/cw-ics721-bridge/src/ibc_tests.rs
@@ -22,6 +22,7 @@ const CONTRACT_PORT: &str = "wasm.address1";
 const REMOTE_PORT: &str = "stars.address1";
 const CONNECTION_ID: &str = "connection-2";
 const CHANNEL_ID: &str = "channel-1";
+const RELAYER_ADDR: &str = "relayer";
 const DEFAULT_TIMEOUT: u64 = 42; // Seconds.
 
 const ADDR1: &str = "addr1";
@@ -406,7 +407,7 @@ fn test_ibc_packet_receive_invalid_packet_data() {
     })
     .unwrap();
 
-    let packet = IbcPacketReceiveMsg::new(mock_packet(data));
+    let packet = IbcPacketReceiveMsg::new(mock_packet(data), Addr::unchecked(RELAYER_ADDR));
     let mut deps = mock_dependencies();
     let env = mock_env();
 
@@ -426,7 +427,7 @@ fn test_ibc_packet_receive_invalid_packet_data() {
 fn test_ibc_packet_receive_missmatched_lengths() {
     let data = build_ics_packet("bad kids", None, vec!["kid A"], vec![], "ekez", "callum");
 
-    let packet = IbcPacketReceiveMsg::new(mock_packet(to_binary(&data).unwrap()));
+    let packet = IbcPacketReceiveMsg::new(mock_packet(to_binary(&data).unwrap()), Addr::unchecked(RELAYER_ADDR));
     let mut deps = mock_dependencies();
     let env = mock_env();
 
@@ -471,7 +472,7 @@ fn test_no_receive_when_paused() {
     })
     .unwrap();
 
-    let packet = IbcPacketReceiveMsg::new(mock_packet(data));
+    let packet = IbcPacketReceiveMsg::new(mock_packet(data), Addr::unchecked(RELAYER_ADDR));
     let mut deps = mock_dependencies();
     let env = mock_env();
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ optimize:
     docker run --rm -v "$(pwd)":/code --platform linux/amd64 \
       --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
       --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-      cosmwasm/workspace-optimizer:0.12.8
+      cosmwasm/workspace-optimizer:0.12.9
 
 unit-test:
     cargo test

--- a/ts-relayer-tests/build.sh
+++ b/ts-relayer-tests/build.sh
@@ -11,7 +11,7 @@ cd "$(git rev-parse --show-toplevel)"
 docker run --rm -v "$(pwd)":/code --platform linux/amd64 \
 	--mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
 	--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-	cosmwasm/workspace-optimizer:0.12.8
+	cosmwasm/workspace-optimizer:0.12.9
 
 mkdir -p ./ts-relayer-tests/internal
 cp ./artifacts/*.wasm ./ts-relayer-tests/internal


### PR DESCRIPTION
From what i know, ibc3 is the norm in cosmos, including this feature seems to be the logic thing to do in ics721.

Small fixes to unit-tests, `ibc_channel_open` change of expected result, and upgrade optimizer version to 0.12.9

Closes #36 