### PR TITLE
ICS-721 spec updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "cw721-rate-limited-proxy",
  "serde",
  "thiserror",
+ "zip-optional",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,21 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.65"
+name = "ahash"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "base16ct"
@@ -16,15 +27,15 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "block-buffer"
@@ -52,9 +63,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cfg-if"
@@ -64,17 +75,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1c26e5595c6a960cd3d6dc1d8629e16a2b0cb22ecd653b28bbf292d7c53a3c"
+checksum = "227315dc11f0bb22a273d0c43d3ba8ef52041c42cf959f09045388a89c57e661"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",
@@ -83,18 +94,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a24050753f242554c558dfe7a6b3a456850f2bc6fcf8b518988720e40a5fa21"
+checksum = "6fca30d51f7e5fbfa6440d8b10d7df0231bdf77e97fd3fe5d0cb79cc4822e50c"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6fe57b9e59a87a406b825cbe647f6456e1a853f8d4c99bffcc20957fd29d6"
+checksum = "04135971e2c3b867eb793ca4e832543c077dbf72edaef7672699190f8fcdb619"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -105,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e8cfc90b557a8ed272c9daf0ff3634e6b9f4698a19832bba6a4c7baa46da04"
+checksum = "a06c8f516a13ae481016aa35f0b5c4652459e8aee65b15b6fb51547a07cea5a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -116,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e50ba8bfea2e449be2e7fa96fd8b196d09fb5ef34e27a18f28835ed835b199"
+checksum = "b13d5a84d15cf7be17dc249a21588cdb0f7ef308907c50ce2723316a7d79c3dc"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -135,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce135cec6c90df7115b0f5b2b40683dd41ac62999dfb002107f6a9f5c345374"
+checksum = "9162c3f85412914d5be2ee650ebdbf11b08e5e9acdebcf4dc03608fb01cf9676"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -211,11 +222,11 @@ dependencies = [
  "cw-multi-test",
  "cw-paginate",
  "cw-pause-once",
- "cw-storage-plus 0.15.1",
- "cw-utils 0.15.1",
- "cw2",
- "cw721",
- "cw721-base",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1",
+ "cw721 0.16.0",
+ "cw721-base 0.16.0",
  "cw721-proxy-derive",
  "cw721-rate-limited-proxy",
  "serde",
@@ -231,23 +242,23 @@ dependencies = [
  "cosmwasm-storage",
  "cw-ics721-bridge",
  "cw-storage-plus 0.15.1",
- "cw2",
+ "cw2 0.15.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f9a8ab7c3c29ec93cb7a39ce4b14a05e053153b4a17ef7cf2246af1b7c087e"
+checksum = "c2eb84554bbfa6b66736abcd6a9bfdf237ee0ecb83910f746dff7f799093c80a"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.13.4",
- "cw-utils 0.13.4",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
  "derivative",
  "itertools",
+ "k256",
  "prost",
  "schemars",
  "serde",
@@ -256,12 +267,12 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate"
-version = "0.2.0"
-source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v2.0.0-beta#2ff37311f4335b6c5b2e49f8d3727313a86a251f"
+version = "2.0.0-beta"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v2.0.0-beta#74bd3881fdd86829e5e8b132b9952dd64f2d0737"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.13.4",
+ "cw-storage-plus 0.16.0",
  "serde",
 ]
 
@@ -279,25 +290,14 @@ dependencies = [
 [[package]]
 name = "cw-rate-limiter"
 version = "0.0.1"
-source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+source = "git+https://github.com/0xekez/cw721-proxy.git#b1c98f5b84f21eac2c5a8a89f18209802ce6a3dd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.1",
+ "cw-storage-plus 0.16.0",
  "schemars",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -312,15 +312,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-utils"
-version = "0.13.4"
+name = "cw-storage-plus"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
+checksum = "d9b6f91c0b94481a3e9ef1ceb183c37d00764f8751e39b45fc09f4d9b970d469"
 dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
- "thiserror",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053a5083c258acd68386734f428a5a171b29f7d733151ae83090c6fcc9417ffa"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -331,7 +341,37 @@ checksum = "0ae0b69fa7679de78825b4edeeec045066aa2b2c4b6e063d80042e565bb4da5c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2",
+ "cw2 0.15.1",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-utils"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a84c6c1c0acc3616398eba50783934bd6c964bad6974241eaee3460c8f5b26"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw2 0.16.0",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw2 1.0.1",
  "schemars",
  "semver",
  "serde",
@@ -352,6 +392,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw2"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.16.0",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb70cee2cf0b4a8ff7253e6bc6647107905e8eb37208f87d54f67810faa62f8"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw721"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +426,19 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils 0.15.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw721"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a1ea6e6277bdd6dfc043a9b1380697fe29d6e24b072597439523658d21d791"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 0.16.0",
  "schemars",
  "serde",
 ]
@@ -374,8 +453,25 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
  "cw-utils 0.15.1",
- "cw2",
- "cw721",
+ "cw2 0.15.1",
+ "cw721 0.15.0",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw721-base"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77518e27431d43214cff4cdfbd788a7508f68d9b1f32389e6fce513e7eaccbef"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.16.0",
+ "cw-utils 0.16.0",
+ "cw2 0.16.0",
+ "cw721 0.16.0",
  "schemars",
  "serde",
  "thiserror",
@@ -384,12 +480,12 @@ dependencies = [
 [[package]]
 name = "cw721-proxy"
 version = "0.0.1"
-source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+source = "git+https://github.com/0xekez/cw721-proxy.git#b1c98f5b84f21eac2c5a8a89f18209802ce6a3dd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "cw721",
+ "cw-storage-plus 0.16.0",
+ "cw721 0.16.0",
  "cw721-proxy-derive",
  "thiserror",
 ]
@@ -397,9 +493,9 @@ dependencies = [
 [[package]]
 name = "cw721-proxy-derive"
 version = "0.0.1"
-source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+source = "git+https://github.com/0xekez/cw721-proxy.git#b1c98f5b84f21eac2c5a8a89f18209802ce6a3dd"
 dependencies = [
- "cw721",
+ "cw721 0.16.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -408,14 +504,14 @@ dependencies = [
 [[package]]
 name = "cw721-rate-limited-proxy"
 version = "0.0.1"
-source = "git+https://github.com/0xekez/cw721-proxy.git#eb53b55290d3ffbe4c355b27ea1113468aaa0635"
+source = "git+https://github.com/0xekez/cw721-proxy.git#b1c98f5b84f21eac2c5a8a89f18209802ce6a3dd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-rate-limiter",
- "cw-storage-plus 0.15.1",
- "cw2",
- "cw721",
+ "cw-storage-plus 0.16.0",
+ "cw2 0.16.0",
+ "cw721 0.16.0",
  "cw721-proxy",
  "cw721-proxy-derive",
  "thiserror",
@@ -428,16 +524,16 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.15.1",
- "cw2",
- "cw721-base",
+ "cw2 0.15.1",
+ "cw721-base 0.15.0",
  "thiserror",
 ]
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -465,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -476,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
@@ -494,16 +590,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
+ "hashbrown",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
  "zeroize",
 ]
 
@@ -522,7 +618,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
+ "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
@@ -535,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -561,24 +657,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -593,6 +678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +698,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -618,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "k256"
@@ -636,9 +730,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -658,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -690,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -702,9 +802,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -712,14 +809,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -728,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schemars"
@@ -772,15 +869,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -796,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -818,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -848,7 +945,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -857,7 +954,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "rand_core 0.6.4",
 ]
 
@@ -885,9 +982,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -896,18 +993,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -916,15 +1013,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -934,21 +1031,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,3 +1052,7 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+
+[[package]]
+name = "zip-optional"
+version = "0.1.0"

--- a/contracts/cw-ics721-bridge-tester/src/msg.rs
+++ b/contracts/cw-ics721-bridge-tester/src/msg.rs
@@ -15,6 +15,8 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+#[allow(clippy::large_enum_variant)] // `data` field is a bit large
+                                     // for clippy's taste.
 pub enum ExecuteMsg {
     CloseChannel {
         channel_id: String,

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -13,13 +13,13 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.1", features = ["stargate"] }
+cosmwasm-std = { version = "1.1", features = ["ibc3"] }
 cosmwasm-schema = "1.1"
-cw-storage-plus = "0.15"
-cw-utils = "0.15"
-cw2 = "0.15"
-cw721 = "0.15"
-cw721-base = { version = "0.15", features = ["library"] }
+cw-storage-plus = "1.0.1"
+cw-utils = "1.0.1"
+cw2 = "1.0.1"
+cw721 = "0.16"
+cw721-base = { version = "0.16", features = ["library"] }
 thiserror = "1"
 serde = "1.0"
 cw-paginate = { git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v2.0.0-beta" }
@@ -28,5 +28,5 @@ cw-pause-once = { path = "../../packages/cw-pause-once" }
 cw-cii = { path = "../../packages/cw-cii" }
 
 [dev-dependencies]
-cw-multi-test = "0.13.4"
+cw-multi-test = "0.16.2"
 cw721-rate-limited-proxy = { git = "https://github.com/0xekez/cw721-proxy.git" }

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -26,6 +26,7 @@ cw-paginate = { git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v2.
 cw721-proxy-derive = { git = "https://github.com/0xekez/cw721-proxy.git" }
 cw-pause-once = { path = "../../packages/cw-pause-once" }
 cw-cii = { path = "../../packages/cw-cii" }
+zip-optional = { path = "../../packages/zip-optional" }
 
 [dev-dependencies]
 cw-multi-test = "0.16.2"

--- a/contracts/cw-ics721-bridge/src/error.rs
+++ b/contracts/cw-ics721-bridge/src/error.rs
@@ -29,6 +29,15 @@ pub enum ContractError {
     #[error("class ID already exists")]
     ClassIdAlreadyExists {},
 
+    #[error("empty class ID")]
+    EmptyClassId {},
+
+    #[error("must transfer at least one token")]
+    NoTokens {},
+
+    #[error("optional fields may not be empty if provided")]
+    EmptyOptional {},
+
     #[error("unrecognised reply ID")]
     UnrecognisedReplyId {},
 
@@ -45,7 +54,7 @@ pub enum ContractError {
         actual: Option<String>,
     },
 
-    #[error("tokenId list has different length than tokenUri list")]
+    #[error("tokenIds, tokenUris, and tokenData must have the same length")]
     TokenInfoLenMissmatch {},
 }
 

--- a/contracts/cw-ics721-bridge/src/ibc.rs
+++ b/contracts/cw-ics721-bridge/src/ibc.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::cw_serde;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_binary, to_binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
+    from_binary, to_binary, Binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
     IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcPacket, IbcPacketAckMsg,
     IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdResult,
     SubMsgResult, WasmMsg,
@@ -12,11 +12,12 @@ use cw_utils::parse_reply_instantiate_data;
 use crate::{
     error::Never,
     ibc_helpers::{ack_fail, ack_success, try_get_ack_error, validate_order_and_version},
-    ibc_packet_receive::do_ibc_packet_receive,
+    ibc_packet_receive::ibc_rx,
     state::{
         CLASS_ID_TO_NFT_CONTRACT, INCOMING_CLASS_TOKEN_TO_CHANNEL, NFT_CONTRACT_TO_CLASS_ID,
         OUTGOING_CLASS_TOKEN_TO_CHANNEL, PROXY,
     },
+    token_types::{ClassId, TokenId},
     ContractError,
 };
 
@@ -35,18 +36,28 @@ pub const IBC_VERSION: &str = "ics721-1";
 #[serde(rename_all = "camelCase")]
 pub struct NonFungibleTokenPacketData {
     /// Uniquely identifies the collection which the tokens being
-    /// transfered belong to on the sending chain.
-    pub class_id: String,
-    /// URL that points to metadata about the collection. This is not
-    /// validated.
+    /// transfered belong to on the sending chain. Must be non-empty.
+    pub class_id: ClassId,
+    /// Optional URL that points to metadata about the
+    /// collection. Must be non-empty if provided.
     pub class_uri: Option<String>,
+    /// Optional base64 encoded field which contains on-chain metadata
+    /// about the NFT class. Must be non-empty if provided.
+    pub class_data: Option<Binary>,
     /// Uniquely identifies the tokens in the NFT collection being
-    /// transfered.
-    pub token_ids: Vec<String>,
-    /// URL that points to metadata for each token being
+    /// transfered. This MUST be non-empty.
+    pub token_ids: Vec<TokenId>,
+    /// Optional URL that points to metadata for each token being
     /// transfered. `tokenUris[N]` should hold the metadata for
-    /// `tokenIds[N]` and both lists should have the same length.
-    pub token_uris: Vec<String>,
+    /// `tokenIds[N]` and both lists should have the same if
+    /// provided. Must be non-empty if provided.
+    pub token_uris: Option<Vec<String>>,
+    /// Optional base64 encoded metadata for the tokens being
+    /// transfered. `tokenData[N]` should hold metadata for
+    /// `tokenIds[N]` and both lists should have the same length if
+    /// provided. Must be non-empty if provided.
+    pub token_data: Option<Vec<Binary>>,
+
     /// The address sending the tokens on the sending chain.
     pub sender: String,
     /// The address that should receive the tokens on the receiving
@@ -117,7 +128,7 @@ pub fn ibc_packet_receive(
     // Regardless of if our processing of this packet works we need to
     // commit an ACK to the chain. As such, we wrap all handling logic
     // in a seprate function and on error write out an error ack.
-    match do_ibc_packet_receive(deps, env, msg.packet) {
+    match ibc_rx(deps, env, msg.packet) {
         Ok(response) => Ok(response),
         Err(error) => Ok(IbcReceiveResponse::new()
             .add_attribute("method", "ibc_packet_receive")
@@ -154,7 +165,9 @@ pub fn ibc_packet_ack(
                     INCOMING_CLASS_TOKEN_TO_CHANNEL.remove(deps.storage, key);
                     messages.push(WasmMsg::Execute {
                         contract_addr: nft_contract.to_string(),
-                        msg: to_binary(&cw721::Cw721ExecuteMsg::Burn { token_id: token })?,
+                        msg: to_binary(&cw721::Cw721ExecuteMsg::Burn {
+                            token_id: token.into(),
+                        })?,
                         funds: vec![],
                     })
                 }
@@ -181,12 +194,12 @@ pub fn ibc_packet_timeout(
     handle_packet_fail(deps, msg.packet, "timeout")
 }
 
+/// Return the NFT locked in the bridge to sender; roll back.
 fn handle_packet_fail(
     deps: DepsMut,
     packet: IbcPacket,
     error: &str,
 ) -> Result<IbcBasicResponse, ContractError> {
-    // Return to sender!
     let message: NonFungibleTokenPacketData = from_binary(&packet.data)?;
     let nft_address = CLASS_ID_TO_NFT_CONTRACT.load(deps.storage, message.class_id.clone())?;
     let sender = deps.api.addr_validate(&message.sender)?;
@@ -202,7 +215,7 @@ fn handle_packet_fail(
                 contract_addr: nft_address.to_string(),
                 msg: to_binary(&cw721::Cw721ExecuteMsg::TransferNft {
                     recipient: sender.to_string(),
-                    token_id,
+                    token_id: token_id.into(),
                 })?,
                 funds: vec![],
             })
@@ -236,9 +249,10 @@ pub fn reply(deps: DepsMut, _env: Env, reply: Reply) -> Result<Response, Contrac
             // We need to map this address back to a class
             // ID. Fourtunately, we set the name of the new NFT
             // contract to the class ID.
-            let cw721::ContractInfoResponse { name: class_id, .. } = deps
+            let cw721::ContractInfoResponse { name, .. } = deps
                 .querier
                 .query_wasm_smart(cw721_addr.clone(), &cw721::Cw721QueryMsg::ContractInfo {})?;
+            let class_id = ClassId::new(name);
 
             // Save classId <-> contract mappings.
             CLASS_ID_TO_NFT_CONTRACT.save(deps.storage, class_id.clone(), &cw721_addr)?;

--- a/contracts/cw-ics721-bridge/src/ibc.rs
+++ b/contracts/cw-ics721-bridge/src/ibc.rs
@@ -3,8 +3,9 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     from_binary, to_binary, DepsMut, Env, IbcBasicResponse, IbcChannelCloseMsg,
-    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcPacket, IbcPacketAckMsg, IbcPacketReceiveMsg,
-    IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdResult, SubMsgResult, WasmMsg,
+    IbcChannelConnectMsg, IbcChannelOpenMsg, IbcChannelOpenResponse, IbcPacket, IbcPacketAckMsg,
+    IbcPacketReceiveMsg, IbcPacketTimeoutMsg, IbcReceiveResponse, Reply, Response, StdResult,
+    SubMsgResult, WasmMsg,
 };
 use cw_utils::parse_reply_instantiate_data;
 
@@ -58,8 +59,9 @@ pub fn ibc_channel_open(
     _deps: DepsMut,
     _env: Env,
     msg: IbcChannelOpenMsg,
-) -> Result<(), ContractError> {
-    validate_order_and_version(msg.channel(), msg.counterparty_version())
+) -> Result<IbcChannelOpenResponse, ContractError> {
+    validate_order_and_version(msg.channel(), msg.counterparty_version())?;
+    Ok(None)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -103,7 +105,6 @@ pub fn ibc_channel_close(
         // closing (bad because the channel is, for all intents and
         // purposes, closed) so we must allow the transaction through.
         IbcChannelCloseMsg::CloseConfirm { channel: _ } => Ok(IbcBasicResponse::default()),
-        _ => unreachable!("https://github.com/CosmWasm/cosmwasm/pull/1449"),
     }
 }
 

--- a/contracts/cw-ics721-bridge/src/ibc_tests.rs
+++ b/contracts/cw-ics721-bridge/src/ibc_tests.rs
@@ -25,6 +25,7 @@ const CHANNEL_ID: &str = "channel-1";
 const DEFAULT_TIMEOUT: u64 = 42; // Seconds.
 
 const ADDR1: &str = "addr1";
+const RELAYER_ADDR: &str = "relayer";
 const CW721_CODE_ID: u64 = 0;
 
 fn mock_channel(channel_id: &str) -> IbcChannel {
@@ -35,7 +36,7 @@ fn mock_channel(channel_id: &str) -> IbcChannel {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Unordered,
         IBC_VERSION,
@@ -230,7 +231,7 @@ fn test_ibc_channel_open_ordered_channel() {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Ordered,
         IBC_VERSION,
@@ -258,7 +259,7 @@ fn test_ibc_channel_open_invalid_version() {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Unordered,
         "invalid_version",
@@ -286,7 +287,7 @@ fn test_ibc_channel_open_invalid_version_counterparty() {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Unordered,
         IBC_VERSION,
@@ -329,7 +330,7 @@ fn test_ibc_channel_connect_ordered_channel() {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Ordered,
         IBC_VERSION,
@@ -357,7 +358,7 @@ fn test_ibc_channel_connect_invalid_version() {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Unordered,
         "invalid_version",
@@ -385,7 +386,7 @@ fn test_ibc_channel_connect_invalid_version_counterparty() {
         },
         IbcEndpoint {
             port_id: REMOTE_PORT.to_string(),
-            channel_id: format!("{}5", channel_id),
+            channel_id: format!("{channel_id}5"),
         },
         IbcOrder::Unordered,
         IBC_VERSION,
@@ -406,7 +407,7 @@ fn test_ibc_packet_receive_invalid_packet_data() {
     })
     .unwrap();
 
-    let packet = IbcPacketReceiveMsg::new(mock_packet(data));
+    let packet = IbcPacketReceiveMsg::new(mock_packet(data), Addr::unchecked(RELAYER_ADDR));
     let mut deps = mock_dependencies();
     let env = mock_env();
 
@@ -426,7 +427,10 @@ fn test_ibc_packet_receive_invalid_packet_data() {
 fn test_ibc_packet_receive_missmatched_lengths() {
     let data = build_ics_packet("bad kids", None, vec!["kid A"], vec![], "ekez", "callum");
 
-    let packet = IbcPacketReceiveMsg::new(mock_packet(to_binary(&data).unwrap()));
+    let packet = IbcPacketReceiveMsg::new(
+        mock_packet(to_binary(&data).unwrap()),
+        Addr::unchecked(RELAYER_ADDR),
+    );
     let mut deps = mock_dependencies();
     let env = mock_env();
 
@@ -471,7 +475,7 @@ fn test_no_receive_when_paused() {
     })
     .unwrap();
 
-    let packet = IbcPacketReceiveMsg::new(mock_packet(data));
+    let packet = IbcPacketReceiveMsg::new(mock_packet(data), Addr::unchecked(RELAYER_ADDR));
     let mut deps = mock_dependencies();
     let env = mock_env();
 

--- a/contracts/cw-ics721-bridge/src/integration_tests.rs
+++ b/contracts/cw-ics721-bridge/src/integration_tests.rs
@@ -386,11 +386,14 @@ fn test_no_proxy_unauthorized() {
 }
 
 // Tests that the proxy can send NFTs via this contract. multi test
-// doesn't support IBC messages and panics with "unsupported type"
-// when you try to send one. If we're sending an IBC message this test
-// has passed though.
+// doesn't support IBC messages and panics with "Unexpected exec msg
+// SendPacket" when you try to send one. If we're sending an IBC
+// message this test has passed though.
+//
+// NOTE: this test may fail when updating multi-test as the panic
+// string may change.
 #[test]
-#[should_panic(expected = "Unsupported type")]
+#[should_panic(expected = "Unexpected exec msg SendPacket")]
 fn test_proxy_authorized() {
     use cw721_rate_limited_proxy as rlp;
 

--- a/contracts/cw-ics721-bridge/src/lib.rs
+++ b/contracts/cw-ics721-bridge/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ibc_helpers;
 pub mod ibc_packet_receive;
 pub mod msg;
 pub mod state;
+pub mod token_types;
 
 #[cfg(test)]
 mod ibc_tests;

--- a/contracts/cw-ics721-bridge/src/msg.rs
+++ b/contracts/cw-ics721-bridge/src/msg.rs
@@ -1,7 +1,9 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::IbcTimeout;
+use cosmwasm_std::{IbcTimeout, WasmMsg};
 use cw721_proxy_derive::cw721_proxy;
 use cw_cii::ContractInstantiateInfo;
+
+use crate::token_types::{ClassId, Token, VoucherCreation, VoucherRedemption};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -43,84 +45,39 @@ pub enum ExecuteMsg {
 
 #[cw_serde]
 pub enum CallbackMsg {
+    CreateVouchers {
+        /// The address that ought to receive the NFT. This is a local
+        /// address, not a bech32 public key.
+        receiver: String,
+        /// Information about the vouchers being created.
+        create: VoucherCreation,
+    },
+    RedeemVouchers {
+        /// The address that should receive the tokens.
+        receiver: String,
+        /// Information about the vouchers been redeemed.
+        redeem: VoucherRedemption,
+    },
     /// Mints a NFT of collection class_id for receiver with the
     /// provided id and metadata. Only callable by this contract.
     Mint {
         /// The class_id to mint for. This must have previously been
         /// created with `SaveClass`.
-        class_id: String,
-        /// Unique identifiers for the tokens.
-        token_ids: Vec<String>,
-        /// Urls pointing to metadata about the NFTs to mint. For
-        /// example, this may point to ERC721 metadata on IPFS. Must
-        /// be the same length as token_ids. token_uris[i] is the
-        /// metadata for token_ids[i].
-        token_uris: Vec<String>,
+        class_id: ClassId,
         /// The address that ought to receive the NFTs. This is a
         /// local address, not a bech32 public key.
         receiver: String,
+        /// The tokens to mint on the collection.
+        tokens: Vec<Token>,
     },
-    /// Much like mint, but will instantiate a new cw721 contract iff
-    /// the classID does not have one yet.
-    InstantiateAndMint {
-        /// The ics721 class ID to mint for.
-        class_id: String,
-        /// The URI for this class ID.
-        class_uri: Option<String>,
-        /// Unique identifiers for the tokens being transfered.
-        token_ids: Vec<String>,
-        /// A list of urls pointing to metadata about the NFTs. For
-        /// example, this may point to ERC721 metadata on ipfs.
-        ///
-        /// Must be the same length as token_ids.
-        token_uris: Vec<String>,
-        /// The address that ought to receive the NFT. This is a local
-        /// address, not a bech32 public key.
-        receiver: String,
-    },
-    /// Transfers a number of NFTs identified by CLASS_ID and
-    /// TOKEN_IDS to RECEIVER.
-    BatchTransfer {
-        /// The ics721 class ID of the tokens to be transfered.
-        class_id: String,
-        /// The address that should receive the tokens.
-        receiver: String,
-        /// The tokens (of CLASS_ID) that should be sent.
-        token_ids: Vec<String>,
-    },
-    /// Handles the falliable part of receiving an IBC
-    /// packet. Transforms TRANSFERS into a `BatchTransfer` message
-    /// and NEW_TOKENS into a `DoInstantiateAndMint`, then dispatches
-    /// those methods.
-    HandlePacketReceive {
-        /// The address receiving the NFTs.
-        receiver: String,
-        /// The URI for the collection being transfered.
-        class_uri: Option<String>,
-        /// Information about transfer actions.
-        transfers: Option<TransferInfo>,
-        /// Information about mint actions.
-        new_tokens: Option<NewTokenInfo>,
-    },
-}
-
-#[cw_serde]
-pub struct TransferInfo {
-    /// The class ID the tokens belong to.
-    pub class_id: String,
-    /// The tokens to be transfered.
-    pub token_ids: Vec<String>,
-}
-
-#[cw_serde]
-pub struct NewTokenInfo {
-    /// The class ID to mint tokens for.
-    pub class_id: String,
-    /// The token IDs of the tokens to be minted.
-    pub token_ids: Vec<String>,
-    /// The URIs of the tokens to be minted. Matched with token_ids by
-    /// index.
-    pub token_uris: Vec<String>,
+    /// In submessage terms, say a message that results in an error
+    /// "returns false" and one that succedes "returns true". Returns
+    /// the logical conjunction (&&) of all the messages in operands.
+    ///
+    /// Under the hood this just executes them in order. We use this
+    /// to respond with a single ACK when a message calls for the
+    /// execution of both `CreateVouchers` and `RedeemVouchers`.
+    Conjunction { operands: Vec<WasmMsg> },
 }
 
 #[cw_serde]
@@ -141,7 +98,7 @@ pub enum QueryMsg {
     /// Gets the classID this contract has stored for a given NFT
     /// contract. If there is no class ID for the provided contract,
     /// returns None.
-    #[returns(Option<String>)]
+    #[returns(Option<ClassId>)]
     ClassId { contract: String },
 
     /// Gets the NFT contract associated wtih the provided class

--- a/contracts/cw-ics721-bridge/src/state.rs
+++ b/contracts/cw-ics721-bridge/src/state.rs
@@ -3,6 +3,8 @@ use cw_pause_once::PauseOrchestrator;
 use cw_storage_plus::{Item, Map};
 use serde::Deserialize;
 
+use crate::token_types::{ClassId, TokenId};
+
 /// The code ID we will use for instantiating new cw721s.
 pub const CW721_CODE_ID: Item<u64> = Item::new("a");
 /// The proxy that this contract is receiving NFTs from, if any.
@@ -12,19 +14,19 @@ pub const PO: PauseOrchestrator = PauseOrchestrator::new("c", "d");
 
 /// Maps classID (from NonFungibleTokenPacketData) to the cw721
 /// contract we have instantiated for that classID.
-pub const CLASS_ID_TO_NFT_CONTRACT: Map<String, Addr> = Map::new("e");
+pub const CLASS_ID_TO_NFT_CONTRACT: Map<ClassId, Addr> = Map::new("e");
 /// Maps cw721 contracts to the classID they were instantiated for.
-pub const NFT_CONTRACT_TO_CLASS_ID: Map<Addr, String> = Map::new("f");
+pub const NFT_CONTRACT_TO_CLASS_ID: Map<Addr, ClassId> = Map::new("f");
 
 /// Maps between classIDs and classUris. We need to keep this state
 /// ourselves as cw721 contracts do not have class-level metadata.
-pub const CLASS_ID_TO_CLASS_URI: Map<String, Option<String>> = Map::new("g");
+pub const CLASS_ID_TO_CLASS_URI: Map<ClassId, Option<String>> = Map::new("g");
 
 /// Maps (class ID, token ID) -> local channel ID. Used to determine
 /// the local channel that NFTs have been sent out on.
-pub const OUTGOING_CLASS_TOKEN_TO_CHANNEL: Map<(String, String), String> = Map::new("h");
+pub const OUTGOING_CLASS_TOKEN_TO_CHANNEL: Map<(ClassId, TokenId), String> = Map::new("h");
 /// Same as above, but for NFTs arriving at this contract.
-pub const INCOMING_CLASS_TOKEN_TO_CHANNEL: Map<(String, String), String> = Map::new("i");
+pub const INCOMING_CLASS_TOKEN_TO_CHANNEL: Map<(ClassId, TokenId), String> = Map::new("i");
 
 #[derive(Deserialize)]
 pub struct UniversalNftInfoResponse {

--- a/contracts/cw-ics721-bridge/src/token_types.rs
+++ b/contracts/cw-ics721-bridge/src/token_types.rs
@@ -1,0 +1,197 @@
+use std::ops::Deref;
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{to_binary, Addr, Binary, StdResult, WasmMsg};
+use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
+
+use crate::msg::{CallbackMsg, ExecuteMsg};
+
+/// A token ID according to the ICS-721 spec. The newtype pattern is
+/// used here to provide some distinction between token and class IDs
+/// in the type system.
+#[cw_serde]
+pub struct TokenId(String);
+
+/// A token according to the ICS-721 spec.
+#[cw_serde]
+pub struct Token {
+    /// A unique identifier for the token.
+    pub id: TokenId,
+    /// Optional URI pointing to off-chain metadata about the token.
+    pub uri: Option<String>,
+    /// Optional base64 encoded metadata about the token.
+    pub data: Option<Binary>,
+}
+
+/// A class ID according to the ICS-721 spec. The newtype pattern is
+/// used here to provide some distinction between token and class IDs
+/// in the type system.
+#[cw_serde]
+pub struct ClassId(String);
+
+#[cw_serde]
+pub struct Class {
+    /// A unique (from the source chain's perspective) identifier for
+    /// the class.
+    pub id: ClassId,
+    /// Optional URI pointing to off-chain metadata about the class.
+    pub uri: Option<String>,
+    /// Optional base64 encoded metadata about the class.
+    pub data: Option<Binary>,
+}
+
+#[cw_serde]
+pub struct VoucherRedemption {
+    /// The class that these vouchers are being redeemed from.
+    pub class: Class,
+    /// The tokens belonging to `class` that ought to be redeemed.
+    pub token_ids: Vec<TokenId>,
+}
+
+#[cw_serde]
+pub struct VoucherCreation {
+    /// The class that these vouchers are being created for.
+    pub class: Class,
+    /// The tokens to create debt-vouchers for.
+    pub tokens: Vec<Token>,
+}
+
+impl TokenId {
+    pub(crate) fn new<T>(token_id: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self(token_id.into())
+    }
+}
+
+impl ClassId {
+    pub(crate) fn new<T>(class_id: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self(class_id.into())
+    }
+}
+
+impl VoucherRedemption {
+    /// Transforms information about a redemption of vouchers into a
+    /// message that may be executed to redeem said vouchers.
+    ///
+    /// ## Arguments
+    ///
+    /// - `contract` the address of the ics721-bridge contract
+    ///    vouchers are being redeemed on.
+    /// - `receiver` that address that ought to receive the NFTs
+    ///   the debt-vouchers are redeemable for.
+    pub(crate) fn into_wasm_msg(self, contract: Addr, receiver: String) -> StdResult<WasmMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr: contract.into_string(),
+            msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::RedeemVouchers {
+                receiver,
+                redeem: self,
+            }))?,
+            funds: vec![],
+        })
+    }
+}
+
+impl VoucherCreation {
+    /// Transforms information abiout the creation of vouchers into a
+    /// message that may be executed to redeem said vouchers.
+    ///
+    /// ## Arguments
+    ///
+    /// - `contract` the address of the ics721-bridge contract
+    ///    vouchers are being created on.
+    /// - `receiver` that address that ought to receive the newly
+    ///   created debt-vouchers.
+    pub(crate) fn into_wasm_msg(self, contract: Addr, receiver: String) -> StdResult<WasmMsg> {
+        Ok(WasmMsg::Execute {
+            contract_addr: contract.into_string(),
+            msg: to_binary(&ExecuteMsg::Callback(CallbackMsg::CreateVouchers {
+                receiver,
+                create: self,
+            }))?,
+            funds: vec![],
+        })
+    }
+}
+
+// boilerplate for conversion between wrappers and the wrapped.
+
+impl From<ClassId> for String {
+    fn from(c: ClassId) -> Self {
+        c.0
+    }
+}
+
+impl From<TokenId> for String {
+    fn from(t: TokenId) -> Self {
+        t.0
+    }
+}
+
+impl Deref for ClassId {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ClassId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// boilerplate for storing these wrapper types in CosmWasm maps.
+
+impl<'a> PrimaryKey<'a> for ClassId {
+    type Prefix = <String as PrimaryKey<'a>>::Prefix;
+    type SubPrefix = <String as PrimaryKey<'a>>::SubPrefix;
+    type Suffix = <String as PrimaryKey<'a>>::Suffix;
+    type SuperSuffix = <String as PrimaryKey<'a>>::SuperSuffix;
+
+    fn key(&self) -> Vec<cw_storage_plus::Key> {
+        self.0.key()
+    }
+}
+
+impl<'a> PrimaryKey<'a> for TokenId {
+    type Prefix = <String as PrimaryKey<'a>>::Prefix;
+    type SubPrefix = <String as PrimaryKey<'a>>::SubPrefix;
+    type Suffix = <String as PrimaryKey<'a>>::Suffix;
+    type SuperSuffix = <String as PrimaryKey<'a>>::SuperSuffix;
+
+    fn key(&self) -> Vec<cw_storage_plus::Key> {
+        self.0.key()
+    }
+}
+
+impl<'a> Prefixer<'a> for ClassId {
+    fn prefix(&self) -> Vec<Key> {
+        self.0.prefix()
+    }
+}
+
+impl<'a> Prefixer<'a> for TokenId {
+    fn prefix(&self) -> Vec<Key> {
+        self.0.prefix()
+    }
+}
+
+impl KeyDeserialize for ClassId {
+    type Output = <String as KeyDeserialize>::Output;
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        String::from_vec(value)
+    }
+}
+
+impl KeyDeserialize for TokenId {
+    type Output = <String as KeyDeserialize>::Output;
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        String::from_vec(value)
+    }
+}

--- a/justfile
+++ b/justfile
@@ -23,3 +23,6 @@ integration-test:
     npm i --prefix ts-relayer-tests && npm run full-test --prefix ts-relayer-tests
 
 test: unit-test simulation-test integration-test
+
+lint:
+	cargo +nightly clippy --all-targets -- -D warnings

--- a/packages/zip-optional/Cargo.toml
+++ b/packages/zip-optional/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zip-optional"
+version = "0.1.0"
+edition = "2021"
+authors = ["ekez <ekez@withoutdoing.com>"]
+description = "an iterator type for zipping with an optional iterator"
+
+[dependencies]

--- a/packages/zip-optional/README.md
+++ b/packages/zip-optional/README.md
@@ -1,0 +1,45 @@
+# Zip Optional
+
+An iterator type for zipping with an optional iterable.
+
+When the iterable being zipped has no value (i.e. is `None`), the
+initial iterable is effectively zipped with `std::iter::repeat(None)`.
+
+```rust
+# use zip_optional::zip_optional;
+
+let a = vec![1, 2];
+
+let mut zipped = zip_optional(a, None::<Vec<i32>>);
+assert_eq!(zipped.next().unwrap(), (1, None));
+assert_eq!(zipped.next().unwrap(), (2, None));
+assert_eq!(zipped.next(), None);
+```
+
+When the iterable being zipped has a value, the result of a sequence
+of `Some(_)` which contains the items in the iterable being zipped
+with.
+
+```rust
+# use zip_optional::zip_optional;
+
+let a = vec![1, 2];
+let b = Some(vec![1, 2]);
+
+let mut zipped = zip_optional(a, b);
+assert_eq!(zipped.next().unwrap(), (1, Some(1)));
+assert_eq!(zipped.next().unwrap(), (2, Some(2)));
+assert_eq!(zipped.next(), None);
+```
+
+The provided iterator may also be used inline with other iteration
+methods, like so:
+
+```rust
+# use zip_optional::Zippable;
+
+let mut zipped = vec![1, 2].into_iter().zip_optional(Some(vec![1, 2]));
+assert_eq!(zipped.next().unwrap(), (1, Some(1)));
+assert_eq!(zipped.next().unwrap(), (2, Some(2)));
+assert_eq!(zipped.next(), None);
+```

--- a/packages/zip-optional/src/lib.rs
+++ b/packages/zip-optional/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-use std::iter::Iterator;
-
 pub enum ZipOptional<A, B> {
     Some { a: A, b: B },
     None { a: A },

--- a/packages/zip-optional/src/lib.rs
+++ b/packages/zip-optional/src/lib.rs
@@ -1,0 +1,129 @@
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
+use std::iter::Iterator;
+
+pub enum ZipOptional<A, B> {
+    Some { a: A, b: B },
+    None { a: A },
+}
+
+impl<A, B> Iterator for ZipOptional<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    type Item = (A::Item, Option<B::Item>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::None { a } => a.next().map(|a| (a, None)),
+            Self::Some { a, b } => {
+                let a = a.next()?;
+                let b = b.next()?;
+                Some((a, Some(b)))
+            }
+        }
+    }
+}
+
+pub fn zip_optional<A, B>(a: A, b: Option<B>) -> ZipOptional<A::IntoIter, B::IntoIter>
+where
+    A: IntoIterator,
+    B: IntoIterator,
+{
+    match b {
+        Some(b) => ZipOptional::Some {
+            a: a.into_iter(),
+            b: b.into_iter(),
+        },
+        None => ZipOptional::None { a: a.into_iter() },
+    }
+}
+
+pub trait Zippable<B>
+where
+    Self: Sized,
+    B: IntoIterator,
+{
+    fn zip_optional(self, b: Option<B>) -> ZipOptional<Self, B::IntoIter>;
+}
+
+impl<I, B> Zippable<B> for I
+where
+    I: Iterator,
+    B: IntoIterator,
+{
+    fn zip_optional(self, b: Option<B>) -> ZipOptional<Self, B::IntoIter> {
+        crate::zip_optional(self, b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zip_optional_some() {
+        let a = vec![1, 2];
+        let b = Some(vec![1, 2]);
+
+        let mut zipped = zip_optional(a, b);
+        assert_eq!(zipped.next().unwrap(), (1, Some(1)));
+        assert_eq!(zipped.next().unwrap(), (2, Some(2)));
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_none() {
+        let a = vec![1, 2];
+
+        let mut zipped = zip_optional(a, None::<Vec<i32>>);
+        assert_eq!(zipped.next().unwrap(), (1, None));
+        assert_eq!(zipped.next().unwrap(), (2, None));
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_empty() {
+        let a = Vec::<i32>::new();
+
+        let mut zipped = zip_optional(a, None::<Vec<i32>>);
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_iter_none() {
+        let mut zipped = vec![1, 2].into_iter().zip_optional(None::<Vec<i32>>);
+        assert_eq!(zipped.next().unwrap(), (1, None));
+        assert_eq!(zipped.next().unwrap(), (2, None));
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_iter_some() {
+        let mut zipped = vec![1, 2].into_iter().zip_optional(Some(vec![1, 2]));
+        assert_eq!(zipped.next().unwrap(), (1, Some(1)));
+        assert_eq!(zipped.next().unwrap(), (2, Some(2)));
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_iter_empty() {
+        let mut zipped = Vec::<i32>::new().into_iter().zip_optional(None::<Vec<i32>>);
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_longer_non_optional() {
+        let mut zipped = vec![1, 2].into_iter().zip_optional(Some(vec![1]));
+        assert_eq!(zipped.next().unwrap(), (1, Some(1)));
+        assert_eq!(zipped.next(), None);
+    }
+
+    #[test]
+    fn test_zip_optional_longer_optional() {
+        let mut zipped = vec![1].into_iter().zip_optional(Some(vec![1, 2]));
+        assert_eq!(zipped.next().unwrap(), (1, Some(1)));
+        assert_eq!(zipped.next(), None);
+    }
+}


### PR DESCRIPTION
this implements the addition of token and class level on-chain metadata in ICS-721.

i have had to step up the abstraction level of the code to do so safely. where possible i have strived to do so without increasing complexity.

todo:
- update integration tests
- store and forward token and class on-chain metadata in the same way that we currently store and forward class_uri.