### PR TITLE
Add instantiate message registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "cw2 1.1.0",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
+ "cw721-init-msg-registry",
  "cw721-proxy-derive",
  "cw721-rate-limited-proxy",
  "serde",
@@ -477,6 +478,16 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "cw721-init-msg-registry"
+version = "0.0.1"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw721-base 0.18.0",
+ "sg721",
 ]
 
 [[package]]
@@ -924,6 +935,20 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sg721"
+version = "3.1.0"
+source = "git+https://github.com/public-awesome/launchpad#980e7038938430b158e616f5d6b1d3c840e5501c"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-ownable",
+ "cw-utils 1.0.1",
+ "cw721-base 0.18.0",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
 name = "cw721-init-msg-registry"
 version = "0.0.1"
 dependencies = [
+ "cfg-if",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw721-base 0.18.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-cii",
  "cw-multi-test",
- "cw-paginate",
+ "cw-paginate-storage",
  "cw-pause-once",
  "cw-storage-plus 1.1.0",
  "cw-utils 1.0.1",
@@ -304,9 +304,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-paginate"
-version = "2.1.0"
-source = "git+https://github.com/arkprotocol/dao-contracts.git#10ce192101c9751c65285f033c93f7a1e34319f0"
+name = "cw-paginate-storage"
+version = "2.2.0"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git#7f89ad1604e8022f202aef729853b0c8c7196988"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,14 @@ cw-multi-test = "0.16"
 cw-utils = "1.0"
 thiserror = "1"
 serde = "1.0"
-cw-paginate-storage = { version = "2.2.0", git = "https://github.com/DA0-DA0/dao-contracts.git" } # TODO: switch to original repo https://github.com/DA0-DA0/dao-contracts once lib versions are updated
+cw-paginate-storage = { version = "2.2.0", git = "https://github.com/DA0-DA0/dao-contracts.git" }
 cw721-proxy-derive = { git = "https://github.com/0xekez/cw721-proxy.git" }
 cw721-rate-limited-proxy = { git = "https://github.com/0xekez/cw721-proxy.git" }
 cw-pause-once = { path = "./packages/cw-pause-once" }
 cw-cii = { path = "./packages/cw-cii" }
 zip-optional = { path = "./packages/zip-optional" }
 cw-ics721-bridge = { path = "./contracts/cw-ics721-bridge"}
+cw721-init-msg-registry = { path = "./packages/cw721-init-msg-registry" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cw-multi-test = "0.16"
 cw-utils = "1.0"
 thiserror = "1"
 serde = "1.0"
-cw-paginate = { git = "https://github.com/arkprotocol/dao-contracts.git" } # TODO: switch to original repo https://github.com/DA0-DA0/dao-contracts once lib versions are updated
+cw-paginate-storage = { version = "2.2.0", git = "https://github.com/DA0-DA0/dao-contracts.git" } # TODO: switch to original repo https://github.com/DA0-DA0/dao-contracts once lib versions are updated
 cw721-proxy-derive = { git = "https://github.com/0xekez/cw721-proxy.git" }
 cw721-rate-limited-proxy = { git = "https://github.com/0xekez/cw721-proxy.git" }
 cw-pause-once = { path = "./packages/cw-pause-once" }

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -22,7 +22,7 @@ cw721 = { workspace = true }
 cw721-base = { workspace = true, features = ["library"] }
 thiserror = { workspace = true }
 serde = { workspace = true }
-cw-paginate = { workspace = true }
+cw-paginate-storage = { workspace = true }
 cw721-proxy-derive = { workspace = true }
 cw-pause-once = { workspace = true }
 cw-cii = { workspace = true }

--- a/contracts/cw-ics721-bridge/Cargo.toml
+++ b/contracts/cw-ics721-bridge/Cargo.toml
@@ -27,6 +27,7 @@ cw721-proxy-derive = { workspace = true }
 cw-pause-once = { workspace = true }
 cw-cii = { workspace = true }
 zip-optional = { workspace = true }
+cw721-init-msg-registry = { workspace = true, features = ["ics721-base", "cw721-base"], default-features = false}
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/contracts/cw-ics721-bridge/src/contract.rs
+++ b/contracts/cw-ics721-bridge/src/contract.rs
@@ -396,7 +396,7 @@ fn query_nft_contracts(
     start_after: Option<ClassId>,
     limit: Option<u32>,
 ) -> StdResult<Vec<(String, Addr)>> {
-    cw_paginate::paginate_map(
+    cw_paginate_storage::paginate_map(
         deps,
         &CLASS_ID_TO_NFT_CONTRACT,
         start_after,
@@ -417,7 +417,7 @@ fn query_channels(
             TokenId::new(class_token.token_id),
         )
     });
-    cw_paginate::paginate_map(
+    cw_paginate_storage::paginate_map(
         deps,
         &class_token_to_channel,
         start_after,

--- a/contracts/cw-ics721-bridge/src/contract.rs
+++ b/contracts/cw-ics721-bridge/src/contract.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     token_types::{Class, ClassId, Token, TokenId, VoucherCreation, VoucherRedemption},
 };
+use cw721_init_msg_registry::{ics721_get_init_msg, InitMsgData};
 
 const CONTRACT_NAME: &str = "crates.io:cw-ics721-bridge";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -279,12 +280,9 @@ fn callback_create_vouchers(
             WasmMsg::Instantiate {
                 admin: None,
                 code_id: CW721_CODE_ID.load(deps.storage)?,
-                msg: to_binary(&cw721_base::msg::InstantiateMsg {
-                    // Name of the collection MUST be class_id as this is how
-                    // we create a map entry on reply.
-                    name: class.id.clone().into(),
-                    symbol: class.id.clone().into(),
-                    minter: env.contract.address.to_string(),
+                msg: ics721_get_init_msg(&InitMsgData {
+                    class_id: class.id.clone().into(),
+                    ics721_addr: env.contract.address.to_string(),
                 })?,
                 funds: vec![],
                 // Attempting to fit the class ID in the label field

--- a/packages/cw721-init-msg-registry/Cargo.toml
+++ b/packages/cw721-init-msg-registry/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Art3mix"]
 [features]
 # We use default feature for development, but must be commented out for production
 # Choose the desired service and NFT contract to work on
-# default    = ["ics721-base", "cw721-base"]
+default    = ["ics721-base", "sg721-base"]
 
 # Service features, to choose which
 ics721-base = []
@@ -23,3 +23,4 @@ cosmwasm-schema = { workspace = true }
 # Contracts based on features
 cw721-base = { version = "0.18.0", optional = true }
 sg721      = { version = "3.1.0", git = "https://github.com/public-awesome/launchpad", optional = true }
+cfg-if = "1.0.0"

--- a/packages/cw721-init-msg-registry/Cargo.toml
+++ b/packages/cw721-init-msg-registry/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name    = "cw721-init-msg-registry"
+version = "0.0.1"
+edition = { workspace = true }
+authors = ["Art3mix"]
+
+[features]
+# We use default feature for development, but must be commented out for production
+# Choose the desired service and NFT contract to work on
+# default    = ["ics721-base", "cw721-base"]
+
+# Service features, to choose which
+ics721-base = []
+
+# NFT contracts features, to choose which init msg to use
+cw721-base = ["dep:cw721-base"]
+sg721-base = ["dep:sg721"]
+
+[dependencies]
+cosmwasm-std    = { workspace = true }
+cosmwasm-schema = { workspace = true }
+
+# Contracts based on features
+cw721-base = { version = "0.18.0", optional = true }
+sg721      = { version = "3.1.0", git = "https://github.com/public-awesome/launchpad", optional = true }

--- a/packages/cw721-init-msg-registry/Cargo.toml
+++ b/packages/cw721-init-msg-registry/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Art3mix"]
 [features]
 # We use default feature for development, but must be commented out for production
 # Choose the desired service and NFT contract to work on
-default    = ["ics721-base", "sg721-base"]
+# default    = ["ics721-base", "sg721-base"]
 
 # Service features, to choose which
 ics721-base = []

--- a/packages/cw721-init-msg-registry/README
+++ b/packages/cw721-init-msg-registry/README
@@ -1,0 +1,5 @@
+# CosmWasm Contract Instantiate Info (cw-cii)
+
+Provides a type `ContractInstantiateInfo` which may be provided as
+part of a contract message and specifies all the needed information
+for instantiating a new contract.

--- a/packages/cw721-init-msg-registry/README
+++ b/packages/cw721-init-msg-registry/README
@@ -1,5 +1,1 @@
-# CosmWasm Contract Instantiate Info (cw-cii)
-
-Provides a type `ContractInstantiateInfo` which may be provided as
-part of a contract message and specifies all the needed information
-for instantiating a new contract.
+# TODO update readme of usage

--- a/packages/cw721-init-msg-registry/src/contracts/cw721.rs
+++ b/packages/cw721-init-msg-registry/src/contracts/cw721.rs
@@ -1,0 +1,12 @@
+use cosmwasm_std::{to_binary, Binary, StdResult};
+
+use crate::data::InitMsgData;
+
+/// Generate cw721-base init message given ics721 data
+pub fn ics721_get_init_msg(data: &InitMsgData) -> StdResult<Binary> {
+    to_binary(&cw721_base::InstantiateMsg {
+        name: data.class_id.to_string(),
+        symbol: data.class_id.to_string(),
+        minter: data.ics721_addr.to_string(),
+    })
+}

--- a/packages/cw721-init-msg-registry/src/contracts/mod.rs
+++ b/packages/cw721-init-msg-registry/src/contracts/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "cw721-base")]
+pub mod cw721;
+#[cfg(feature = "cw721-base")]
+pub use cw721::ics721_get_init_msg;
+
+#[cfg(feature = "sg721-base")]
+pub mod sg721;
+#[cfg(feature = "sg721-base")]
+pub use cw721::ics721_get_init_msg;

--- a/packages/cw721-init-msg-registry/src/contracts/mod.rs
+++ b/packages/cw721-init-msg-registry/src/contracts/mod.rs
@@ -1,9 +1,13 @@
 #[cfg(feature = "cw721-base")]
 pub mod cw721;
-#[cfg(feature = "cw721-base")]
-pub use cw721::ics721_get_init_msg;
 
 #[cfg(feature = "sg721-base")]
 pub mod sg721;
-#[cfg(feature = "sg721-base")]
-pub use cw721::ics721_get_init_msg;
+
+cfg_if::cfg_if! {
+  if #[cfg(feature = "sg721-base")] {
+    pub use self::sg721::ics721_get_init_msg;
+  } else {
+    pub use self::cw721::ics721_get_init_msg;
+  }
+}

--- a/packages/cw721-init-msg-registry/src/contracts/sg721.rs
+++ b/packages/cw721-init-msg-registry/src/contracts/sg721.rs
@@ -1,0 +1,21 @@
+use cosmwasm_std::{to_binary, Binary, StdResult};
+
+use crate::data::Ics721Data;
+
+/// Generate sg721 init message given ics721 data
+pub fn ics721_get_init_msg(data: &Ics721Data) -> StdResult<Binary> {
+    to_binary(&sg721::InstantiateMsg {
+        name: data.class_id.to_string(),
+        symbol: data.class_id.to_string(),
+        minter: data.ics721_addr.to_string(),
+        collection_info: sg721::CollectionInfo {
+            creator: data.ics721_addr.to_string(),
+            description: "Ics721 created collection".to_string(),
+            image: "".to_string(),
+            external_link: None,
+            explicit_content: None,
+            start_trading_time: None,
+            royalty_info: None,
+        },
+    })
+}

--- a/packages/cw721-init-msg-registry/src/contracts/sg721.rs
+++ b/packages/cw721-init-msg-registry/src/contracts/sg721.rs
@@ -1,9 +1,9 @@
 use cosmwasm_std::{to_binary, Binary, StdResult};
 
-use crate::data::Ics721Data;
+use crate::data::InitMsgData;
 
 /// Generate sg721 init message given ics721 data
-pub fn ics721_get_init_msg(data: &Ics721Data) -> StdResult<Binary> {
+pub fn ics721_get_init_msg(data: &InitMsgData) -> StdResult<Binary> {
     to_binary(&sg721::InstantiateMsg {
         name: data.class_id.to_string(),
         symbol: data.class_id.to_string(),

--- a/packages/cw721-init-msg-registry/src/data.rs
+++ b/packages/cw721-init-msg-registry/src/data.rs
@@ -1,0 +1,9 @@
+use cosmwasm_schema::cw_serde;
+
+/// Struct to passdata from ics721 base contracts to the init msg function
+#[cfg(feature = "ics721-base")]
+#[cw_serde]
+pub struct InitMsgData {
+  pub class_id: String,
+  pub ics721_addr: String,
+}

--- a/packages/cw721-init-msg-registry/src/data.rs
+++ b/packages/cw721-init-msg-registry/src/data.rs
@@ -4,6 +4,6 @@ use cosmwasm_schema::cw_serde;
 #[cfg(feature = "ics721-base")]
 #[cw_serde]
 pub struct InitMsgData {
-  pub class_id: String,
-  pub ics721_addr: String,
+    pub class_id: String,
+    pub ics721_addr: String,
 }

--- a/packages/cw721-init-msg-registry/src/lib.rs
+++ b/packages/cw721-init-msg-registry/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod data;
 mod contracts;
+mod data;
 
 // IMPORTANT: Make sure to remove default features and only enable the wanted feature
 pub use contracts::ics721_get_init_msg;

--- a/packages/cw721-init-msg-registry/src/lib.rs
+++ b/packages/cw721-init-msg-registry/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod data;
+mod contracts;
+
+// IMPORTANT: Make sure to remove default features and only enable the wanted feature
+pub use contracts::ics721_get_init_msg;
+pub use data::InitMsgData;


### PR DESCRIPTION
Adds a way for ics721 to use different cw721 contracts without a need for codebase changes.

We would still need to use 2 ics721 contracts, 1 that uses "cw721-base" feature and one that uses "sg721-base" feature, but the difference is that the code of core ics721 doesn't change.

So development on ics721 can continue as usual, an any ics721 that uses different cw721 can easily pull update from core ics721, and the only change that would be needed is to change the features of the registry.

Benefits:
1. No changes to core ics721 are needed in case of updates
2. very easy to add new implementation not only for cw721 contracts but also for service like ics721 

Drawbacks:
1. Can't use in a workspace with 2 different features, features are additive, meaning the first contract will enable feature X, the second contract will have feature X without explicitly adding it.
This only true for optimizing workspaces, as a workaround its possible to optimize each contract separately. 
2. If you do update from core ics721, you will need to modify the feature of the registry dependency, 

Some stuff to do:

- [ ] Verify tests are still working for both types (cw721 and sg721)
- [ ] Update readme to better explain usage
- [ ] Do a step by step mini guide on how to implement new cw721 contracts into the registry